### PR TITLE
Remove incorrect scalable icon file

### DIFF
--- a/in.srev.guiscrcpy.yml
+++ b/in.srev.guiscrcpy.yml
@@ -123,5 +123,3 @@ modules:
       - install -D appimage/guiscrcpy.desktop /app/share/applications/in.srev.guiscrcpy.desktop
       - install -D appimage/guiscrcpy-128.png /app/share/app-info/icons/flatpak/128x128/in.srev.guiscrcpy.png
       - install -D appimage/guiscrcpy-256.png /app/share/app-info/icons/flatpak/256x256/in.srev.guiscrcpy.png
-      - install -D appimage/guiscrcpy.png /app/share/icons/hicolor/scalable/apps/in.srev.guiscrcpy.png
-


### PR DESCRIPTION
The 490x490 png file is not a scalable (svg) one and causes the guiscrcpy icon to not display correctly on Flathub.org / in GNOME Software.

/cc @srevinsaju