### PR TITLE
Mark guiscrcpy as EOL

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,42 @@
+From 407f0f69c664587bfb77c86404f39dc790be0aae Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <161761531+yakushabb@users.noreply.github.com>
+Date: Thu, 18 Dec 2025 03:51:45 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ appimage/guiscrcpy.appdata.xml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/appimage/guiscrcpy.appdata.xml b/appimage/guiscrcpy.appdata.xml
+index 16569f7..1b215e5 100644
+--- a/appimage/guiscrcpy.appdata.xml
++++ b/appimage/guiscrcpy.appdata.xml
+@@ -2,22 +2,24 @@
+ <component type="desktop-application">
+ 	<id>in.srev.guiscrcpy</id>
+ 	<name>guiscrcpy</name>
++	<developer_name>Srevin Saju</developer_name>
+     <metadata_license>MIT</metadata_license>
+     <project_license>GPL-3.0+</project_license>
+     <summary>Android Screen Mirroring Software</summary>
+     <description>
+       <p>A user friendly, open source android screen mirroring client built on top of scrcpy
+         </p>
+     </description>
+     <content_rating type="oars-1.1"/>
+-    <launchable type="desktop-id">guiscrcpy.desktop</launchable>
++    <launchable type="desktop-id">in.srev.guiscrcpy.desktop</launchable>
+     <screenshots>
+         <screenshot type="default">
+           <image>https://raw.githubusercontent.com/srevinsaju/guiscrcpy/main/docs/img/screenshot.jpg</image>
+           <caption>Screenshot showing a demo of guiscrcpy's functionality</caption>
+         </screenshot>
+     </screenshots>
+     <url type="homepage">https://github.com/srevinsaju/guiscrcpy</url>
++    <url type="vcs-browser">https://github.com/srevinsaju/guiscrcpy</url>
+     <provides>
+         <binary>python{{ python-version }}</binary>
+     </provides>
+--
+libgit2 1.7.2
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }

--- a/in.srev.guiscrcpy.yml
+++ b/in.srev.guiscrcpy.yml
@@ -115,12 +115,13 @@ modules:
       - type: git
         url: https://github.com/srevinsaju/guiscrcpy
         commit: 66249d4ec960b8392d75fd2a360975fe51393a46
+      - type: patch
+        path: fix_appdata.patch
 
       - type: file
         url: https://files.pythonhosted.org/packages/09/79/5ab16fbf2d9354c242e9f9e784d604dd06842405f7797e71238f3c053200/poetry_core-1.0.7-py2.py3-none-any.whl
         sha256: 4f8a7f5390d772f42c4c4c3f188e6424b802cb4b57466c6633a1b9ac36f18a43
     post-install:
-      - sed -i "/\<launchable/d" appimage/guiscrcpy.appdata.xml
       - install -Dm644 appimage/guiscrcpy.appdata.xml /app/share/metainfo/in.srev.guiscrcpy.appdata.xml
       - desktop-file-edit --set-key=Icon --set-value=in.srev.guiscrcpy ./appimage/guiscrcpy.desktop
       - install -Dm644 appimage/guiscrcpy.desktop /app/share/applications/in.srev.guiscrcpy.desktop


### PR DESCRIPTION
> This repository was archived by the owner on Dec 29, 2023. It is now read-only.

Source: https://github.com/srevinsaju/guiscrcpy